### PR TITLE
Gpio sample fixes

### DIFF
--- a/samples/gpio-pci-idio-16.c
+++ b/samples/gpio-pci-idio-16.c
@@ -91,6 +91,15 @@ int main(int argc, char *argv[])
         err(EXIT_FAILURE, "missing MUSER device UUID");
     }
 
+    if (trans_sock) {
+        char *uuid = argv[optind];
+        for (int i = 0; i < strlen(uuid); i++) {
+            if (uuid[i] == '-') {
+                memmove(&uuid[i], &uuid[i + 1], strlen(uuid) - i);
+            }
+        }
+    }
+
     lm_dev_info_t dev_info = {
         .trans = trans_sock ? LM_TRANS_SOCK : LM_TRANS_KERNEL,
         .log = verbose ? _log : NULL,

--- a/samples/gpio-pci-idio-16.c
+++ b/samples/gpio-pci-idio-16.c
@@ -82,7 +82,7 @@ int main(int argc, char *argv[])
                 verbose = true;
                 break;
             default: /* '?' */
-                fprintf(stderr, "Usage: %s [-s] [-d] UUID\n", argv[0]);
+                fprintf(stderr, "Usage: %s [-s] [-v] UUID\n", argv[0]);
                 exit(EXIT_FAILURE);
         }
     }


### PR DESCRIPTION
I don't know if this is the right place where to _clean_ the uuid. The problem is that if the uuid arrives with hyphens in the function `open_sock` (https://github.com/tmakatos/muser/blob/vfio-over-socket/lib/libmuser.c#L161) `strtoul` will fail.