### PR TITLE
muser: use the correct PCI_COMMAND interrupt disable(ID) bit

### DIFF
--- a/lib/libmuser.c
+++ b/lib/libmuser.c
@@ -1019,19 +1019,6 @@ lm_irq_trigger(lm_ctx_t *lm_ctx, uint32_t vector)
         return -1;
     }
 
-    if (vector == LM_DEV_INTX_IRQ_IDX && !lm_ctx->pci_config_space->hdr.cmd.id) {
-        lm_log(lm_ctx, LM_ERR, "failed to trigger INTx IRQ, INTx disabled\n");
-        errno = EINVAL;
-        return -1;
-    } else if (vector == LM_DEV_MSIX_IRQ_IDX) {
-        /*
-         * FIXME must check that MSI-X capability exists during creation time
-         * FIXME need to check that MSI-X is enabled and that it's not masked.
-         * Currently that's not possible because libmuser doesn't care about
-         * the internals of a capability.
-         */
-    }
-
     return eventfd_write(lm_ctx->irqs.efds[vector], val);
 }
 

--- a/lib/libmuser_pci.c
+++ b/lib/libmuser_pci.c
@@ -153,13 +153,13 @@ handle_command_write(lm_ctx_t *ctx, lm_pci_config_space_t *pci,
     if ((v & PCI_COMMAND_INTX_DISABLE) == PCI_COMMAND_INTX_DISABLE) {
         if (!pci->hdr.cmd.id) {
             pci->hdr.cmd.id = 0x1;
-            lm_log(ctx, LM_INF, "INTx emulation enabled\n");
+            lm_log(ctx, LM_INF, "INTx emulation disabled\n");
         }
         v &= ~PCI_COMMAND_INTX_DISABLE;
     } else {
         if (pci->hdr.cmd.id) {
             pci->hdr.cmd.id = 0x0;
-            lm_log(ctx, LM_INF, "INTx emulation disabled\n");
+            lm_log(ctx, LM_INF, "INTx emulation enabled\n");
         }
     }
 


### PR DESCRIPTION
When PCI_COMMAND interrupt disable bit set to 1, it means
disable the pin-based INTx interrupt.

For NVMe controller, it will use INTx first, and then switch
to MSIX, the interrupt vector 0 is both valid for INTx and
MSIX, so here we remove the check when posting an interrupt,
just check the interrupt fd is valid or not.

Signed-off-by: Changpeng Liu <changpeng.liu@intel.com>