### PR TITLE
MSIX Implementation for Linux Kernel >= 5.0.0

### DIFF
--- a/lib/cap.c
+++ b/lib/cap.c
@@ -232,11 +232,13 @@ caps_create(const lm_cap_t *lm_caps, int nr_caps)
             goto out;
         }
 
+#define ALIGN(x,a)              __ALIGN_MASK(x,(typeof(x))(a)-1)
+#define __ALIGN_MASK(x,mask)    (((x)+(mask))&~(mask))
+
         caps->caps[i].id = lm_caps[i].id;
         caps->caps[i].fn = lm_caps[i].fn;
-        /* FIXME PCI capabilities must be dword aligned. */
         caps->caps[i].start = prev_end + 1;
-        caps->caps[i].end = prev_end = caps->caps[i].start + lm_caps[i].size - 1;
+        caps->caps[i].end = prev_end = caps->caps[i].start + ALIGN(lm_caps[i].size, 8) - 1;
     }
     caps->nr_caps = nr_caps;
 

--- a/lib/muser.h
+++ b/lib/muser.h
@@ -131,6 +131,11 @@ void *lm_mmap(lm_ctx_t * lm_ctx, off_t offset, size_t length);
 typedef struct  {
 
     /*
+     * Will this BAR contains MSIX structures?
+     */
+    uint8_t             is_msix;
+
+    /*
      * Region flags, see LM_REG_FLAG_XXX above.
      */
     uint32_t            flags;


### PR DESCRIPTION
Some comments on this PR:

- I would have gladly used the already existing `flags` member of `lm_reg_info_t` instead of adding the new `is_msix` one. But I couldn't because `flags` is directly used as VFIO flags.
- From PCIe specification capabilities don't need to be contiguous but this break somehow libmuser `cap.c` implementation. So I ended up with `caps->caps[i].end = prev_end = caps->caps[i].start + ALIGN(lm_caps[i].size, 8) - 1;` to ensure DWORD alignment. This is not the best option because there could be a (very rare/impossible) case were to the callback function it will be asked to read/write an offset greater than what it's expecting.
I needed the DWORD alignment because `PCI_CAP_ID_MSIX` is 12bytes
- When QEMU finds a region that expose `VFIO_REGION_INFO_CAP_MSIX_MAPPABLE` capability, it will mmap it as follows:
```c
        region->mmaps[i].mmap = mmap(NULL, region->mmaps[i].size, prot,
                                     MAP_SHARED, region->vbasedev->fd,
                                     region->fd_offset +
                                     region->mmaps[i].offset);
```
The _problem_ is that libmuser derives the `fd_offset` of each region accordingly to the function `region_to_offset` -> ` return (uint64_t)region << LM_REGION_SHIFT;`, a huge shift. That's why I decided that MSIX structures should reside on BAR 0.